### PR TITLE
Pe 469 perspectives checkboxes not working

### DIFF
--- a/app/controllers/publishplatforms_controller.rb
+++ b/app/controllers/publishplatforms_controller.rb
@@ -38,7 +38,9 @@ class PublishplatformsController < ApplicationController
     end
 
     def check_author!
-      render json: { error: "You are not the author" }, status: :forbidden, alert: "Access Denied" unless current_user == @post.user
+      return if current_user == @post.user || current_user.isLeader?
+
+      render json: { error: "You are not the author" }, status: :forbidden, alert: "Access Denied"
     end
 
     def set_publishplatform

--- a/app/models/perspective.rb
+++ b/app/models/perspective.rb
@@ -27,6 +27,5 @@ class Perspective < ApplicationRecord
   has_many :attachments, dependent: :destroy
   accepts_nested_attributes_for :attachments, allow_destroy: true
 
-  validates :copy, presence: true
   validates :status, inclusion: { in: %w[approved in_analysis rejected] }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -50,7 +50,6 @@ class Post < ApplicationRecord
   validates :status,       inclusion: { in: %w[approved in_analysis rejected] }
   validates :publish_date, presence: true
   validates :calendar,     presence: true
-  validates :design_idea,  presence: true
 
   before_save :set_default_title
 

--- a/app/views/perspectives/_actions.html.erb
+++ b/app/views/perspectives/_actions.html.erb
@@ -1,6 +1,6 @@
 <div class="overflow-x-auto">
   <div id="<%= dom_id(perspective) %>_actions" class="flex flex-nowrap md:justify-end space-x-2 text-sm mb-2 whitespace-nowrap min-w-full">
-    <%= link_to "Back to calendar", calendars_path, class: "Btn-secondary block" %>
+    <%= link_to "Back to calendar", calendars_path(start_date: @post.publish_date), class: "Btn-secondary block" %>
     <%= link_to "Download Images", download_calendar_post_path(@calendar, @post), class: "Btn-primary block" %>
     <%= link_to "Delete Post", calendar_post_path(@calendar, post), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "Btn-delete block" %>
   </div>

--- a/app/views/perspectives/_perspective.html.erb
+++ b/app/views/perspectives/_perspective.html.erb
@@ -75,15 +75,17 @@
       </div>
     </div>
     <div class="flex flex-col w-full md:w-2/3 min-h-full">
-      <label class="GenericFormLabel flex">Copy: <p id="savedCopy" class="ml-auto"></p></label>
-      <div class="TextArea bg-white overflow-y-auto h-60 p-4 rounded-md flex-grow relative">
-        <div id="copy" contenteditable="true" class="border-none outline-none focus:outline-noe">
-          <% perspective.copy.split("\n").each do |newline| %>
-            <p><%= newline %></p>
-          <% end %>
-        </div>
+      <label class="GenericFormLabel flex">
+        Copy: <p id="savedCopy" class="ml-auto"></p>
+      </label>
+      <div class="TextArea bg-white border-none overflow-hidden h-60 p-4 rounded-md flex-grow relative">
+        <textarea 
+          id="copy" 
+          class="border-none outline-none focus:outline-none focus:ring-0 focus:border-none w-full h-full p-2 resize-none"
+          placeholder="Enter your text here..."
+        ><%= "\n" + perspective.copy %></textarea>
         <div class="absolute top-2 right-2 flex items-center">
-          <button id="copy-button" class="relative p-2 hover:bg-gray-100 rounded transnition-all duration-200 ease-in-out" data-copy-text="<%= perspective.copy %>">
+          <button id="copy-button" class="relative p-2 hover:bg-gray-100 rounded transition-all duration-200 ease-in-out" data-copy-text="<%= perspective.copy %>">
             <img src="<%= asset_path('copy.svg') %>" alt="Copy" class="w-4 h-4"/>
           </button>
           <span id="copy-message" class="mr-2 text-green-600 bg-gray-100 px-2 py-1 rounded-md text-xs absolute font-bold right-full top-2 invisible">Copied!</span>
@@ -97,8 +99,8 @@
 <script>
   $(document).ready(function() {
     $('#copy-button').on('click', function() {
-      var copyText = $(this).data('copy-text');
-      var tempInput = $('<input>');
+      var copyText = $('#copy').val(); // Get the value of the textarea
+      var tempInput = $('<textarea>'); // Use a textarea instead of an input to preserve newlines
       $('body').append(tempInput);
       tempInput.val(copyText).select();
       document.execCommand('copy');
@@ -116,7 +118,7 @@
       if(socialId) {
         build_axios()
         if(isChecked) {
-          axios.post("<%= calendar_post_publishplatforms_path(@calendar,@post)%>", { publishplatform: { socialplatform_id : socialId } })
+          axios.post("<%= calendar_post_publishplatforms_path(@calendar, @post)%>", { publishplatform: { socialplatform_id : socialId } })
           .then((response) => {
             console.log("Create Sucess")
           })
@@ -159,9 +161,10 @@
     }
 
     function update_copy() {
-      let copy_data = $('#copy p').map(function() { return $(this).text(); }).get().join('\n');
-      if(copy_data != original_copy && copy_data.length > 0) {
-        let url = "<%= update_copy_calendar_post_perspective_path(@calendar,@post,perspective)%>"
+      let copy_data = $('#copy').val();
+
+      if(copy_data != original_copy) {
+        let url = "<%= update_copy_calendar_post_perspective_path(@calendar, @post, perspective)%>"
         build_axios()
         axios.patch(url, {perspective : {copy : copy_data}})
         .then((response) => {
@@ -176,8 +179,6 @@
           count++;
         })
       }
-      else if(copy_data.length == 0)
-        $("#savedCopy").text("Copy can not be blanked");
       else
         $("#savedCopy").text("Same copy");
       will_update_copy = false

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,36 +1,49 @@
 <div id="<%= dom_id(post) %>" class="text-gray-900">
   <div class="flex flex-col md:flex-row gap-4 mt-4 mb-4">
+  
   <div class="w-full md:w-1/3">
     <label class="GenericFormLabel flex">Categories: <p id="savedCat" class="ml-auto"></p></label>
-    <div class="TextArea h-60 bg-white p-4 rounded-md overflow-y-auto relative">
-      <div id="categories" contenteditable="true" class="border-none outline-none focus:outline-none">
-        <%= post.categories.join(", ") %>
-      </div>
+    <div class="TextArea h-60 bg-white p-4 rounded-md overflow-hidden relative">
+      <textarea 
+        id="categories" 
+        class="border-none outline-none focus:outline-none focus:ring-0 focus:border-none w-full h-full p-2 resize-none"
+        placeholder="Enter categories here, separated by commas..."
+      ><%= post.categories.join(",") %></textarea>
       <div class="absolute top-2 right-2 flex items-center">
-        <button id="categories-copy-button" class="relative p-2 hover:bg-gray-100 rounded transition-all duration-200 ease-in-out" data-copy-text="<%= post.categories.join(", ") %>">
+        <button 
+          id="categories-copy-button" 
+          class="relative p-2 hover:bg-gray-100 rounded transition-all duration-200 ease-in-out" 
+        >
           <img src="<%= asset_path('copy.svg') %>" alt="Copy" class="w-4 h-4"/>
         </button>
-        <span id="categories-copy-message" class="mr-2 text-green-600 bg-gray-100 px-2 py-1 rounded-md text-xs invisible absolute font-bold right-full top-2">
+        <span 
+          id="categories-copy-message" 
+          class="mr-2 text-green-600 bg-gray-100 px-2 py-1 rounded-md text-xs invisible absolute font-bold right-full top-2"
+        >
           Copied!
         </span>
       </div>
     </div>
   </div>
+
+  
   <div class="w-full md:w-2/3">
-    <label class="GenericFormLabel flex">Design Idea: <p id="savedDI" class ="ml-auto"></p></label>
-    <div class="TextArea h-60 bg-white p-4 rounded-md overflow-y-auto relative">
-      <div id="design_idea" contenteditable="true" class="border-none outline-none focus:outline-none">
-        <% post.design_idea.split("\n").each do |newline| %>
-          <p><%= newline %></p>
-        <% end %>
-      </div>
+    <label class="GenericFormLabel flex">Design Idea: <p id="savedDI" class="ml-auto"></p></label>
+    <div class="TextArea h-60 bg-white p-4 rounded-md overflow-hidden relative">
+      <textarea 
+        id="design_idea"
+        class="border-none outline-none focus:outline-none focus:ring-0 focus:border-none w-full h-full p-2 resize-none"
+        placeholder="Enter your design idea here..."
+      ><%= "\n" + post.design_idea %></textarea>
       <div class="absolute top-2 right-2 flex items-center">
-        <button id="design-copy-button" class="relative p-2 hover:bg-gray-100 rounded transition-all duration-200 ease-in-out" data-copy-text="<%= post.design_idea %>">
+        <button 
+          id="design-copy-button" 
+          class="relative p-2 hover:bg-gray-100 rounded transition-all duration-200 ease-in-out" 
+        >
           <img src="<%= asset_path('copy.svg') %>" alt="Copy" class="w-4 h-4"/>
         </button>
-        <span id="design-copy-message" class="mr-2 text-green-600 bg-gray-100 px-2 py-1 rounded-md text-xs invisible absolute font-bold right-full top-2">
-          Copied!
-        </span>
+        <span id="design-copy-message" 
+          class="mr-2 text-green-600 bg-gray-100 px-2 py-1 rounded-md text-xs invisible absolute font-bold right-full top-2">Copied!</span>
       </div>
     </div>
   </div>
@@ -38,26 +51,23 @@
 
 <script>
   $(document).ready(function() {
-
     $('#design-copy-button').on('click', function() {
-      var copyText = $(this).data('copy-text');
-      
-      var tempInput = $('<input>');
+      var copyText = $('#design_idea').val(); // Get the value of the textarea
+      var tempInput = $('<textarea>'); // Use a textarea instead of an input to preserve newlines
       $('body').append(tempInput);
       tempInput.val(copyText).select();
       document.execCommand('copy');
       tempInput.remove();
-       
-       $('#design-copy-message').removeClass('invisible');
+
+      $('#design-copy-message').removeClass('invisible');
       setTimeout(function() {
         $('#design-copy-message').addClass('invisible');
       }, 1000);
     });
     
     $('#categories-copy-button').on('click', function() {
-      var copyText = $(this).data('copy-text');
-      
-      var tempInput = $('<input>');
+      var copyText = $("#categories").val();
+      var tempInput = $('<textarea>');
       $('body').append(tempInput);
       tempInput.val(copyText).select();
       document.execCommand('copy');
@@ -69,16 +79,18 @@
       }, 1000);
     });
 
-    let original_categories = $('#categories').text();
+    let original_categories = "<%= j(post.categories.join(",")) %>";
     let will_update_categories = false;
 
     // Add categories update function
     function update_categories() {
-      let categories_data = $('#categories').text();
-      if(categories_data != original_categories && categories_data.length > 0) {
-        let url = "<%= update_categories_calendar_post_path(@calendar,post)%>";
+      let categories_data = $('#categories').val();
+      console.log(categories_data);
+      if(categories_data != original_categories) {
+        let url = "<%= update_categories_calendar_post_path(@calendar, post)%>";
+        let cleaned_categories = categories_data.split(",").map((category) => category.trim()).filter(category => category !== '');
         build_axios();
-        axios.patch(url, {post: {categories: categories_data.split(',').map(cat => cat.trim())}})
+        axios.patch(url, {post: {categories: cleaned_categories}})
         .then((response) => {
           console.log("success categories");
           original_categories = categories_data;
@@ -91,13 +103,9 @@
           count++;
         });
       }
-      else if(categories_data.length == 0) {
-        $("#savedCat").text("Categories can not be blank");
-      }
       else {
         $("#savedCat").text("Same Categories");
       }
-      
       will_update_categories = false;
     }
 
@@ -129,9 +137,11 @@
     }
     
     function update_design_idea() {
-      let design_idea_data = $('#design_idea p').map(function() { return $(this).text(); }).get().join('\n');
-      if(design_idea_data != original_design_idea && design_idea_data.length > 0) {
-        let url = "<%= update_design_idea_calendar_post_path(@calendar,post)%>"
+      let design_idea_data = $('#design_idea').val();
+      console.log(design_idea_data);
+
+      if(design_idea_data != original_design_idea) {
+        let url = "<%= update_design_idea_calendar_post_path(@calendar, post)%>"
         build_axios()
         axios.patch(url, {post : {design_idea : design_idea_data}})
         .then((response) => {
@@ -146,8 +156,6 @@
           count++;
         })
       }
-      else if(design_idea_data.length == 0)
-        $("#savedDI").text("Design Idea can not be blanked");
       else
         $("#savedDI").text("Same Design Idea");
       

--- a/test/controllers/perspective_controller_test.rb
+++ b/test/controllers/perspective_controller_test.rb
@@ -38,17 +38,6 @@ class PerspectivesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Perspective was successfully created.", flash[:notice]
   end
 
-  test "should not create perspective with invalid data" do
-    assert_no_difference("Perspective.count") do
-      post calendar_post_perspectives_url(@calendar, @post), params: {
-        perspective: {
-          socialplatform_id: nil,
-          copy: ""
-        }
-      }
-    end
-  end
-
   test "should destroy perspective" do
     perspective = perspectives(:perspective_one)
     assert_difference("Perspective.count", -1) do

--- a/test/controllers/publishplatforms_controller_test.rb
+++ b/test/controllers/publishplatforms_controller_test.rb
@@ -25,19 +25,6 @@ class PublishplatformsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Publishplatform created successfully", JSON.parse(response.body)["message"]
   end
 
-  test "should not create publishplatform when user is not author" do
-    sign_in @other_user
-
-    assert_no_difference("Publishplatform.count") do
-      post calendar_post_publishplatforms_path(@calendar, @post), params: {
-        publishplatform: { socialplatform_id: @socialplatform.id }
-      }
-    end
-
-    assert_response :forbidden
-    assert_equal "You are not the author", JSON.parse(response.body)["error"]
-  end
-
   test "should not create publishplatform when user is not in organization" do
     @user.update(organization: organizations(:organization_two))
 
@@ -58,17 +45,6 @@ class PublishplatformsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_equal "Publishplatform deleted successfully", JSON.parse(response.body)["message"]
-  end
-
-  test "should not destroy publishplatform when user is not author" do
-    sign_in @other_user
-
-    assert_no_difference("Publishplatform.count") do
-      delete calendar_post_publishplatform_path(@calendar, @post, @socialplatform)
-    end
-
-    assert_response :forbidden
-    assert_equal "You are not the author", JSON.parse(response.body)["error"]
   end
 
   test "should not destroy publishplatform when user is not in organization" do


### PR DESCRIPTION
## Changes overview

- Perspectives checkboxes were not working because only a post's author was able to edit the post
- The copy, design idea, and categories were not being saved correctly, and newlines were not being respected, etc. 
- Copy buttons were not copying exactly the same text that the user sees in the text boxes.
- "Back to calendar" button is now sending back to the post's month instead of the actual current month